### PR TITLE
Async Retry on Subgraph requests

### DIFF
--- a/tooling/package.json
+++ b/tooling/package.json
@@ -50,6 +50,7 @@
     "@gnosis.pm/safe-singleton-factory": "^1.0.11",
     "@openzeppelin/contracts": "4.8.0",
     "@openzeppelin/merkle-tree": "^1.0.1",
+    "async-retry": "^1.3.3",
     "date-fns": "^2.29.3",
     "eslint-plugin-prettier": "^4.2.1",
     "fs-extra": "^10.1.0",

--- a/tooling/src/config.ts
+++ b/tooling/src/config.ts
@@ -101,7 +101,7 @@ export function getProviders(hre: HardhatRuntimeEnvironment) {
   );
 
   const gc = new hre.ethers.providers.JsonRpcProvider(
-    `https://rpc.gnosischain.com `,
+    `https://rpc.gnosischain.com`,
   );
 
   return { mainnet, gc };

--- a/tooling/src/fns/calculateAmountToBridge.ts
+++ b/tooling/src/fns/calculateAmountToBridge.ts
@@ -13,10 +13,10 @@ export default async function calculateAmountToBridge(
   let totalMainnet = BigNumber.from(0);
   let totalGC = BigNumber.from(0);
 
-  for (const { mainnet, gc } of reversedSchedule) {
+  for (const { mainnet, gnosis } of reversedSchedule) {
     const allocationMainnet = loadAllocation("mainnet", mainnet.blockNumber);
     assert(!!allocationMainnet);
-    const allocationGC = loadAllocation("gc", gc.blockNumber);
+    const allocationGC = loadAllocation("gnosis", gnosis.blockNumber);
     assert(!!allocationGC);
 
     totalMainnet = totalMainnet.add(snapshotSum(allocationMainnet));

--- a/tooling/src/fns/calculateNetworkAllocation.ts
+++ b/tooling/src/fns/calculateNetworkAllocation.ts
@@ -14,12 +14,12 @@ export default async function calculateNetworkAllocation(
   // just re-use allocation math to figure how much (for this vestingSlice)
   // does Mainnet get, and how much does GC get
   const result = calculateAllocation(
-    { mainnet: snapshotSum(balancesMainnet), gc: snapshotSum(balancesGC) },
+    { mainnet: snapshotSum(balancesMainnet), gnosis: snapshotSum(balancesGC) },
     amountVested,
   );
 
   const allocatedToMainnet = BigNumber.from(result.mainnet || 0);
-  const allocatedToGC = BigNumber.from(result.gc || 0);
+  const allocatedToGC = BigNumber.from(result.gnosis || 0);
   // sanity check
   assert(allocatedToMainnet.add(allocatedToGC).eq(amountVested));
 

--- a/tooling/src/fns/scheduleFind.test.ts
+++ b/tooling/src/fns/scheduleFind.test.ts
@@ -43,7 +43,7 @@ const schedule = [
       timestamp: 1669585787,
       blockNumber: 16064111,
     },
-    gc: {
+    gnosis: {
       timestamp: 1669585785,
       blockNumber: 25189669,
     },
@@ -53,7 +53,7 @@ const schedule = [
       blockNumber: 16073062,
       timestamp: 1669693703,
     },
-    gc: {
+    gnosis: {
       timestamp: 1669693700,
       blockNumber: 25209530,
     },
@@ -63,7 +63,7 @@ const schedule = [
       blockNumber: 16081212,
       timestamp: 1669792067,
     },
-    gc: {
+    gnosis: {
       timestamp: 1669792065,
       blockNumber: 25227679,
     },

--- a/tooling/src/fns/scheduleFind.ts
+++ b/tooling/src/fns/scheduleFind.ts
@@ -1,4 +1,4 @@
-import { Schedule, ScheduleEntry } from "../persistence";
+import { Schedule } from "../persistence";
 
 export default function findEntry(schedule: Schedule, blockNumber: number) {
   const index = schedule.findIndex(

--- a/tooling/src/fns/scheduleValidate.ts
+++ b/tooling/src/fns/scheduleValidate.ts
@@ -20,10 +20,10 @@ export default async function (
             .getBlock(entry.mainnet.blockNumber)
             .then(({ timestamp }) => timestamp),
           providers.gc
-            .getBlock(entry.gc.blockNumber)
+            .getBlock(entry.gnosis.blockNumber)
             .then(({ timestamp }) => timestamp),
         ])
-      : [entry.mainnet.timestamp, entry.gc.timestamp];
+      : [entry.mainnet.timestamp, entry.gnosis.timestamp];
 
     if (
       !(interval.left <= timestampMainnet && timestampMainnet <= interval.right)
@@ -35,7 +35,7 @@ export default async function (
 
     if (!(interval.left <= timestampGC && timestampGC <= interval.right)) {
       throw new Error(
-        `GC block ${entry.gc.blockNumber} in schedule at position ${i} does not match interval`,
+        `GC block ${entry.gnosis.blockNumber} in schedule at position ${i} does not match interval`,
       );
     }
 

--- a/tooling/src/persistence.ts
+++ b/tooling/src/persistence.ts
@@ -8,7 +8,7 @@ import { Snapshot } from "./types";
 export type Schedule = ScheduleEntry[];
 export type ScheduleEntry = {
   mainnet: BlockAndTimestamp;
-  gc: BlockAndTimestamp;
+  gnosis: BlockAndTimestamp;
 };
 export type BlockAndTimestamp = { blockNumber: number; timestamp: number };
 
@@ -29,7 +29,7 @@ function scheduleFilePath() {
 }
 
 export function loadAllocation(
-  chain: "mainnet" | "gc",
+  chain: "mainnet" | "gnosis",
   block: number,
 ): Snapshot | null {
   const filePath = allocationFilePath(chain, block);
@@ -37,7 +37,7 @@ export function loadAllocation(
 }
 
 export function saveAllocation(
-  chain: "mainnet" | "gc",
+  chain: "mainnet" | "gnosis",
   block: number,
   allocation: Snapshot,
 ) {
@@ -46,7 +46,7 @@ export function saveAllocation(
   writeSnapshot(filePath, allocation);
 }
 
-export function allocationFilePath(chain: "mainnet" | "gc", block: number) {
+export function allocationFilePath(chain: "mainnet" | "gnosis", block: number) {
   return path.resolve(
     path.join(
       __dirname,

--- a/tooling/src/queries/querySubgraph.ts
+++ b/tooling/src/queries/querySubgraph.ts
@@ -77,7 +77,7 @@ function withRetry(
         retries: 3,
         onRetry: () => {
           console.info(
-            `retying request:\nURL: ${url}\nQUERY: ${query}\nOPTIONS: ${JSON.stringify(
+            `retrying request:\nURL: ${url}\nQUERY: ${query}\nOPTIONS: ${JSON.stringify(
               options,
             )}`,
           );

--- a/tooling/src/queries/querySubgraph.ts
+++ b/tooling/src/queries/querySubgraph.ts
@@ -11,13 +11,13 @@ const request = withPaging(withRetry(gqlRequest));
 
 export async function queryBalancesMainnet(
   block: number,
-  withLGNO: boolean,
+  withLgno: boolean,
 ): Promise<Snapshot> {
-  if (!withLGNO) {
+  if (!withLgno) {
     return {};
   }
 
-  const userBalances = await request(mainnetEndpoint, lgnoQuery, {
+  const userBalances = await request(urlMainnet, queryLgno, {
     block,
   });
 
@@ -26,13 +26,13 @@ export async function queryBalancesMainnet(
 
 export async function queryBalancesGC(
   block: number,
-  withLGNO: boolean,
+  withLgno: boolean,
 ): Promise<Snapshot> {
   const [balancesWithLgno, balancesWithDeposit, balancesWithStaked] =
     await Promise.all([
-      withLGNO ? request(gcEndpoint, lgnoQuery, { block }) : [],
-      request(gcEndpoint, depositQuery, { block }),
-      request(gcEndpoint, stakedQuery, { block }),
+      withLgno ? request(urlGnosis, queryLgno, { block }) : [],
+      request(urlGnosis, queryDeposit, { block }),
+      request(urlGnosis, queryStaked, { block }),
     ]);
 
   const s1 = aggregate(balancesWithLgno);
@@ -87,13 +87,13 @@ function withRetry(
   };
 }
 
-const mainnetEndpoint =
+const urlMainnet =
   "https://api.thegraph.com/subgraphs/id/QmYNFPz2j1S8wdm2nhou6wRhGXfVVFzVi37LKuvcHBayip";
 
-const gcEndpoint =
+const urlGnosis =
   "https://api.thegraph.com/subgraphs/id/QmbJaRFT59ANkbqXHHCkR6euNyTBD2ypnwek9Gneohx8ha";
 
-const lgnoQuery = gql`
+const queryLgno = gql`
   query ($block: Int, $lastId: String) {
     users(
       block: { number: $block }
@@ -106,7 +106,7 @@ const lgnoQuery = gql`
   }
 `;
 
-const depositQuery = gql`
+const queryDeposit = gql`
   query ($block: Int, $lastId: String) {
     users(
       block: { number: $block }
@@ -119,7 +119,7 @@ const depositQuery = gql`
   }
 `;
 
-const stakedQuery = gql`
+const queryStaked = gql`
   query ($block: Int, $lastId: String) {
     users(
       block: { number: $block }
@@ -132,7 +132,7 @@ const stakedQuery = gql`
   }
 `;
 
-export default function aggregate(users: UserBalance[]): Snapshot {
+function aggregate(users: UserBalance[]): Snapshot {
   if (users.length === 0) {
     return {};
   }

--- a/tooling/src/tasks/allocate.ts
+++ b/tooling/src/tasks/allocate.ts
@@ -55,7 +55,7 @@ task(
         ? loadAllocation("mainnet", entry.mainnet.blockNumber)
         : null;
       const allocationsGC = lazy
-        ? loadAllocation("gc", entry.gc.blockNumber)
+        ? loadAllocation("gnosis", entry.gnosis.blockNumber)
         : null;
 
       if (!allocationsMainnet || !allocationsGC) {
@@ -98,9 +98,9 @@ async function _writeOne(
   log: (text: string) => void,
 ) {
   const blockMainnet = entry.mainnet.blockNumber;
-  const blockGC = entry.gc.blockNumber;
+  const blockGC = entry.gnosis.blockNumber;
 
-  log(`mainnet ${blockMainnet} gc ${blockGC}`);
+  log(`mainnet ${blockMainnet} gnosis ${blockGC}`);
   const { balancesMainnet, balancesGC, amountVested } =
     await fetchAllocationFigures(prevEntry, entry, providers.mainnet, log);
 
@@ -117,7 +117,7 @@ async function _writeOne(
   assert(snapshotSum(allocationGC).eq(allocatedToGC));
 
   saveAllocation("mainnet", blockMainnet, snapshotSort(allocationMainnet));
-  saveAllocation("gc", blockGC, snapshotSort(allocationGC));
+  saveAllocation("gnosis", blockGC, snapshotSort(allocationGC));
 }
 
 async function fetchAllocationFigures(
@@ -128,19 +128,19 @@ async function fetchAllocationFigures(
 ) {
   const ignore = {
     mainnet: [DAO_ADDRESS_MAINNET],
-    gc: [DAO_ADDRESS_GC],
+    gnosis: [DAO_ADDRESS_GC],
   };
 
   const withLGNO =
     entry.mainnet.timestamp < TOKEN_LOCK_OPEN_TIMESTAMP &&
-    entry.gc.timestamp < TOKEN_LOCK_OPEN_TIMESTAMP;
+    entry.gnosis.timestamp < TOKEN_LOCK_OPEN_TIMESTAMP;
 
   log?.(`Considering LGNO: ${withLGNO ? "yes" : "no"}`);
 
   let [balancesMainnet, balancesGC, prevAmountVested, amountVested] =
     await Promise.all([
       queryBalancesMainnet(entry.mainnet.blockNumber, withLGNO),
-      queryBalancesGC(entry.gc.blockNumber, withLGNO),
+      queryBalancesGC(entry.gnosis.blockNumber, withLGNO),
       prevEntry
         ? queryAmountVested(
             VESTING_POOL_ADDRESS,
@@ -160,7 +160,7 @@ async function fetchAllocationFigures(
   assert(amountVested.gte(prevAmountVested));
 
   balancesMainnet = snapshotWithout(balancesMainnet, ignore.mainnet);
-  balancesGC = snapshotWithout(balancesGC, ignore.gc);
+  balancesGC = snapshotWithout(balancesGC, ignore.gnosis);
 
   return {
     balancesMainnet,

--- a/tooling/src/tasks/checkpoint.ts
+++ b/tooling/src/tasks/checkpoint.ts
@@ -23,7 +23,7 @@ task("checkpoint:generate", "").setAction(async () => {
       "mainnet",
       entry.mainnet.blockNumber,
     );
-    const allocationGC = loadAllocation("gc", entry.gc.blockNumber);
+    const allocationGC = loadAllocation("gnosis", entry.gnosis.blockNumber);
 
     if (!allocationMainnet) {
       throw new Error(
@@ -32,7 +32,9 @@ task("checkpoint:generate", "").setAction(async () => {
     }
 
     if (!allocationGC) {
-      throw new Error(`GC Allocation Not Calculated ${entry.gc.blockNumber}`);
+      throw new Error(
+        `Gnosis Allocation Not Calculated ${entry.gnosis.blockNumber}`,
+      );
     }
 
     checkpointMainnet = snapshotMerge(checkpointMainnet, allocationMainnet);

--- a/tooling/src/tasks/distribute.ts
+++ b/tooling/src/tasks/distribute.ts
@@ -27,7 +27,7 @@ task("distribute", "")
 
     await hre.run("schedule:expand");
 
-    await hre.run("allocation:write-all");
+    await hre.run("allocate:write-all");
 
     const [merkleRootMainnet, merkleRootGC] = await hre.run(
       "checkpoint:generate",

--- a/tooling/src/tasks/schedule.ts
+++ b/tooling/src/tasks/schedule.ts
@@ -75,7 +75,10 @@ task(
           ...nextSchedule,
           {
             mainnet: mainnetEntry,
-            gc: { timestamp: blockGC.timestamp, blockNumber: blockGC.number },
+            gnosis: {
+              timestamp: blockGC.timestamp,
+              blockNumber: blockGC.number,
+            },
           },
         ];
       }

--- a/tooling/yarn.lock
+++ b/tooling/yarn.lock
@@ -1443,6 +1443,13 @@ async-eventemitter@^0.2.4:
   dependencies:
     async "^2.4.0"
 
+async-retry@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
+  integrity sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==
+  dependencies:
+    retry "0.13.1"
+
 async@1.x:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -5196,6 +5203,11 @@ restore-cursor@^3.1.0:
   dependencies:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
+
+retry@0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
+  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
 
 reusify@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
Harvest was failing on the inception run because some subgraph requests were flaky. Use a retry for graphql fetch.

Also took the change to clarity rename schedule.gc -> schedule.gnosis