### PR TITLE
Fix amount used to build the merkle tree on the client

### DIFF
--- a/claim-gui/src/hooks/useAllocation.tsx
+++ b/claim-gui/src/hooks/useAllocation.tsx
@@ -69,7 +69,7 @@ function computeProof(
 
   const leaves = Object.keys(distribution).map((address) => [
     address,
-    BigNumber.from(distribution[addressLowerCase]),
+    BigNumber.from(distribution[address]),
   ]);
 
   const index = leaves.findIndex(([_address]) => _address === addressLowerCase);


### PR DESCRIPTION
The merkle tree was being computed with the claimer allocation instead of the actual leaf's allocation